### PR TITLE
Escape special characters

### DIFF
--- a/src/commands/slack-jahia.yml
+++ b/src/commands/slack-jahia.yml
@@ -33,7 +33,7 @@ steps:
       steps:
         - run:
             name: Set the Docker command variable
-            command: echo 'export DOCKER_COMMAND="```docker pull jahia/<< parameters.docker_repo >>:<< parameters.docker_image_tag >>```"' >> $BASH_ENV
+            command: echo 'export DOCKER_COMMAND="\`\`\`docker pull jahia/<< parameters.docker_repo >>:<< parameters.docker_image_tag >>\`\`\`"' >> $BASH_ENV
   - when:
       condition:
         equal: ["pass", << parameters.job_event >>]


### PR DESCRIPTION
Hope this will be the final fix for this issue

Here's what I have locally:
```
~$ export DOCKER_COMMAND="```docker pull jahia/<< parameters.docker_repo >>:<< parameters.docker_image_tag >>```"
-bash: warning: here-document at line 1 delimited by end-of-file (wanted `parameters.docker_repo')
-bash: warning: here-document at line 1 delimited by end-of-file (wanted `parameters.docker_image_tag')
-bash: command substitution: line 1: syntax error near unexpected token `newline'
-bash: command substitution: line 1: `docker pull jahia/<< parameters.docker_repo >>:<< parameters.docker_image_tag >>'
~$ export DOCKER_COMMAND="\`\`\`docker pull jahia/<< parameters.docker_repo >>:<< parameters.docker_image_tag >>\`\`\`"
~$ echo $DOCKER_COMMAND
```docker pull jahia/<< parameters.docker_repo >>:<< parameters.docker_image_tag >>```
```
