### PR TITLE
[semver:patch] - Fixed some yarn issues and changed default resource class for integration tests

### DIFF
--- a/src/jobs/initialize.yml
+++ b/src/jobs/initialize.yml
@@ -44,7 +44,7 @@ steps:
       name: Run yarn if packages.json exists in test folder
       command: |
         if [[ -d << parameters.tests_path >> && -e "<< parameters.tests_path >>package.json" ]]; then
-          cd << parameters.module_path >>
+          cd << parameters.tests_path >>
           yarn
         fi
   - save_cache:

--- a/src/jobs/integration-tests.yml
+++ b/src/jobs/integration-tests.yml
@@ -9,7 +9,7 @@ description: >
 parameters:
   resource_class:
     type: string
-    default: "large"
+    default: "xlarge"
     description: "CircleCI resource_class (small, medium, large, xlarge, ...)"
   working_directory:
     type: string

--- a/src/jobs/static-analysis.yml
+++ b/src/jobs/static-analysis.yml
@@ -42,6 +42,10 @@ docker:
 steps:
   - attach_workspace:
       at: .
+  - run:
+      name: Add eslint as a global package
+      command: |
+        sudo yarn global add eslint      
   - lint:
       module_path: << parameters.module_path >>
       tests_path: << parameters.tests_path >>

--- a/src/jobs/static-analysis.yml
+++ b/src/jobs/static-analysis.yml
@@ -45,7 +45,7 @@ steps:
   - run:
       name: Add eslint as a global package
       command: |
-        sudo yarn global add eslint      
+        sudo yarn global add eslint
   - lint:
       module_path: << parameters.module_path >>
       tests_path: << parameters.tests_path >>


### PR DESCRIPTION
I was initially using "large" as the default resource class for integration tests, but I suspect this was actually the cause of some flakiness. Increased to xlarge (the prior config for integration tests with Jahia).
