### PR TITLE
SELENIUM-1462: fix inconsistency in setting the sonar.projectKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # orb.yml is "packed" from source, and not published directly from the repository.
 orb.yml
+/.project

--- a/src/commands/sonar-analysis.yml
+++ b/src/commands/sonar-analysis.yml
@@ -29,7 +29,6 @@ steps:
           git rev-parse origin/<< parameters.primary_release_branch >>
           echo "Executing a PR based analysis"
           mvn -s .circleci/.circleci.settings.xml sonar:sonar \
-              -Dsonar.projectKey=<< parameters.module_id >> \
               -Dsonar.pullrequest.branch=$CIRCLE_BRANCH \
               -Dsonar.pullrequest.key=${CIRCLE_PULL_REQUEST##*/} \
               -Dsonar.pullrequest.base=<< parameters.primary_release_branch >> \
@@ -37,7 +36,7 @@ steps:
         elif [[ "$CIRCLE_BRANCH" == << parameters.primary_release_branch >> ]]; then
           echo "Executing an analysis on the main branch"
           mvn -s .circleci/.circleci.settings.xml dependency-check:aggregate sonar:sonar \
-              -Dsonar.projectKey=<< parameters.module_id >> $DEPENDENCY_CHECK_SETTINGS
+              $DEPENDENCY_CHECK_SETTINGS
         else
           echo "Executing an analysis on branch: $CIRCLE_BRANCH"
           mvn -s .circleci/.circleci.settings.xml dependency-check:aggregate sonar:sonar \

--- a/src/commands/sonar-analysis.yml
+++ b/src/commands/sonar-analysis.yml
@@ -6,9 +6,6 @@ parameters:
     type: string
     default: "main"
     description: "Name of the primary release branch (master, main, ...)"
-  module_id:
-    type: string
-    description: "ID of the module"
   github_slug:
     type: string
     description: "GitHub SLUG of the module (for example: jahia/sandbox)"

--- a/src/examples/sonar-analysis.yml
+++ b/src/examples/sonar-analysis.yml
@@ -10,5 +10,4 @@ usage:
       jobs:
         - jahia-modules-orb/sonar-analysis:
             primary_release_branch: main
-            module_id: sanbox
             github_slug: jahia/sandbox

--- a/src/jobs/sonar-analysis.yml
+++ b/src/jobs/sonar-analysis.yml
@@ -6,9 +6,6 @@ parameters:
     type: string
     default: "main"
     description: "Name of the primary release branch (master, main, ...)"
-  module_id:
-    type: string
-    description: "ID of the module"
   github_slug:
     type: string
     description: "GitHub SLUG of the module (for example: jahia/sandbox)"
@@ -45,7 +42,6 @@ steps:
         - v2-sonar-owasp-dependencies-
   - sonar-analysis:
       github_slug: << parameters.github_slug >>
-      module_id: << parameters.module_id >>
       primary_release_branch: << parameters.primary_release_branch >>
   - save_cache:
       paths:


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/SELENIUM-1462

## Description

For branches the sonar.projectKey was taken from Maven, but for the primary release branch and for PRs it was explicitly set, leading to duplicated projects on SonarQube.

I think it is better to take the one from Maven as it has the groupId and the artifactId - less risk of conflict.

This inconsistency is there since the beginning of the sandbox module, so it has spread to other modules. We will have to adapt there, too, and then we need to delete the duplicated projects on SonarQube (the ones having the primary release branch).

Actually the passing of the module_id parameter is even no longer necessary as the parameter is not used inside. We should maybe delete it, which should be done carefully as it is an orb function now - unless we want to keep it for eventual future uses (???)
