### PR TITLE
step back to 6.1.6 version of the dependency-check plugin

### DIFF
--- a/src/commands/sonar-analysis.yml
+++ b/src/commands/sonar-analysis.yml
@@ -36,11 +36,11 @@ steps:
               -Dsonar.pullrequest.github.repository=<< parameters.github_slug >>
         elif [[ "$CIRCLE_BRANCH" == << parameters.primary_release_branch >> ]]; then
           echo "Executing an analysis on the main branch"
-          mvn -s .circleci/.circleci.settings.xml org.owasp:dependency-check-maven:aggregate sonar:sonar \
+          mvn -s .circleci/.circleci.settings.xml org.owasp:dependency-check-maven:6.1.6:aggregate sonar:sonar \
               $DEPENDENCY_CHECK_SETTINGS
         else
           echo "Executing an analysis on branch: $CIRCLE_BRANCH"
-          mvn -s .circleci/.circleci.settings.xml org.owasp:dependency-check-maven:aggregate sonar:sonar \
+          mvn -s .circleci/.circleci.settings.xml org.owasp:dependency-check-maven:6.1.6:aggregate sonar:sonar \
               -Dsonar.branch.name=$CIRCLE_BRANCH $DEPENDENCY_CHECK_SETTINGS
         fi
       no_output_timeout: << parameters.no_output_timeout >>


### PR DESCRIPTION
## Description

Use hardcoded 6.1.6 version of dependency-check-maven as this problem is running into timeouts : https://github.com/jeremylong/DependencyCheck/issues/3408 

We should then rather set a configured version in jahia-parent/pom.xml
