### PR TITLE
[semver:patch] - Various updates to the orb (audit-ci, sonar, integration tests)

### DIFF
--- a/src/commands/security.yml
+++ b/src/commands/security.yml
@@ -35,7 +35,7 @@ steps:
           audit-ci --<< parameters.auditci_level >>
         fi
   - run:
-      name: Lint tests (javascript only)
+      name: Audit-ci tests (javascript only)
       command: |
         if [[ -d << parameters.tests_path >> && -e "<< parameters.tests_path >>package.json" ]]; then
           cd << parameters.tests_path >>

--- a/src/commands/security.yml
+++ b/src/commands/security.yml
@@ -17,7 +17,12 @@ parameters:
   auditci_level:
     type: string
     default: "moderate"
-    description: "Security level to check against, will fail the step if higher"
+    description: "Security level to check against for the module codebase, will fail the step if higher"
+  auditci_level_tests:
+    type: string
+    default: "critical"
+    description: "Security level to check against for the tests codebase, will fail the step if higher"
+
 steps:
   - run:
       name: Install Audit-ci
@@ -34,5 +39,5 @@ steps:
       command: |
         if [[ -d << parameters.tests_path >> && -e "<< parameters.tests_path >>package.json" ]]; then
           cd << parameters.tests_path >>
-          audit-ci --<< parameters.auditci_level >>
+          audit-ci --<< parameters.auditci_level_tests >>
         fi

--- a/src/commands/sonar-analysis.yml
+++ b/src/commands/sonar-analysis.yml
@@ -32,10 +32,10 @@ steps:
               -Dsonar.pullrequest.github.repository=<< parameters.github_slug >>
         elif [[ "$CIRCLE_BRANCH" == << parameters.primary_release_branch >> ]]; then
           echo "Executing an analysis on the main branch"
-          mvn -s .circleci/.circleci.settings.xml dependency-check:aggregate sonar:sonar \
+          mvn -s .circleci/.circleci.settings.xml org.owasp:dependency-check-maven:aggregate sonar:sonar \
               $DEPENDENCY_CHECK_SETTINGS
         else
           echo "Executing an analysis on branch: $CIRCLE_BRANCH"
-          mvn -s .circleci/.circleci.settings.xml dependency-check:aggregate sonar:sonar \
+          mvn -s .circleci/.circleci.settings.xml org.owasp:dependency-check-maven:aggregate sonar:sonar \
               -Dsonar.branch.name=$CIRCLE_BRANCH $DEPENDENCY_CHECK_SETTINGS
         fi

--- a/src/commands/sonar-analysis.yml
+++ b/src/commands/sonar-analysis.yml
@@ -36,11 +36,11 @@ steps:
               -Dsonar.pullrequest.github.repository=<< parameters.github_slug >>
         elif [[ "$CIRCLE_BRANCH" == << parameters.primary_release_branch >> ]]; then
           echo "Executing an analysis on the main branch"
-          mvn -s .circleci/.circleci.settings.xml org.owasp:dependency-check-maven:aggregate sonar:sonar \
+          mvn -s .circleci/.circleci.settings.xml org.owasp:dependency-check-maven:6.1.6:aggregate sonar:sonar \
               $DEPENDENCY_CHECK_SETTINGS
         else
           echo "Executing an analysis on branch: $CIRCLE_BRANCH"
-          mvn -s .circleci/.circleci.settings.xml org.owasp:dependency-check-maven:aggregate sonar:sonar \
+          mvn -s .circleci/.circleci.settings.xml org.owasp:dependency-check-maven:6.1.6:aggregate sonar:sonar \
               -Dsonar.branch.name=$CIRCLE_BRANCH $DEPENDENCY_CHECK_SETTINGS
         fi
       no_output_timeout: << parameters.no_output_timeout >>

--- a/src/commands/sonar-analysis.yml
+++ b/src/commands/sonar-analysis.yml
@@ -9,6 +9,10 @@ parameters:
   github_slug:
     type: string
     description: "GitHub SLUG of the module (for example: jahia/sandbox)"
+  no_output_timeout:
+    description: Maximum acceptable period of time to be passed with no output.
+    type: string
+    default: "15m"
 steps:
   - run:
       name: Sonar Release branch analysis
@@ -39,3 +43,4 @@ steps:
           mvn -s .circleci/.circleci.settings.xml org.owasp:dependency-check-maven:aggregate sonar:sonar \
               -Dsonar.branch.name=$CIRCLE_BRANCH $DEPENDENCY_CHECK_SETTINGS
         fi
+      no_output_timeout: << parameters.no_output_timeout >>

--- a/src/jobs/integration-tests.yml
+++ b/src/jobs/integration-tests.yml
@@ -246,7 +246,7 @@ steps:
         docker-compose logs -t --tail="all" > ./artifacts/results/all-containers.log
         docker logs jahia > ./artifacts/results/jahia.log
         docker logs << parameters.tests_container_name >> > ./artifacts/results/<< parameters.tests_container_name >>.log
-        cp ./artifacts/docker-ps.log ./artifacts/results/
+        cp ./artifacts/docker.log ./artifacts/results/
 
   # This is not needed since cypress is going to terminat on failure with exit code 1
   - run:

--- a/src/jobs/integration-tests.yml
+++ b/src/jobs/integration-tests.yml
@@ -194,7 +194,7 @@ steps:
 
   # Pull the latest version of ${JAHIA_IMAGE}
   - run:
-      name: Pull the latest version of Jahia: ${JAHIA_IMAGE}
+      name: Pull the latest version of Jahia
       command: |
         cd << parameters.tests_path >>
         . ./set-env.sh

--- a/src/jobs/integration-tests.yml
+++ b/src/jobs/integration-tests.yml
@@ -194,14 +194,14 @@ steps:
 
   # Pull the latest version of ${JAHIA_IMAGE}
   - run:
-      name: Pull the latest version of the docker images listed in compose
+      name: Pull the latest version of Jahia: ${JAHIA_IMAGE}
       command: |
         cd << parameters.tests_path >>
         . ./set-env.sh
         echo "List of docker images in local cache PRIOR pull" > ./artifacts/docker.log
         docker images --digests --all 2>&1 | tee -a ./artifacts/docker.log
         echo "--------------------------------------------------" >> ./artifacts/docker.log
-        docker-compose -f << parameters.docker_compose_file >> pull
+        docker pull ${JAHIA_IMAGE}
         echo "List of docker images in local cache AFTER pull" > ./artifacts/docker.log
         docker images --digests --all 2>&1 | tee -a ./artifacts/docker.log
         echo "--------------------------------------------------" >> ./artifacts/docker.log

--- a/src/jobs/integration-tests.yml
+++ b/src/jobs/integration-tests.yml
@@ -194,7 +194,7 @@ steps:
 
   # Pull the latest version of ${JAHIA_IMAGE}
   - run:
-      name: Pull the latest version of Jahia
+      name: Pull the latest version of Jahia and print docker images cache to console
       command: |
         cd << parameters.tests_path >>
         . ./set-env.sh

--- a/src/jobs/integration-tests.yml
+++ b/src/jobs/integration-tests.yml
@@ -202,10 +202,10 @@ steps:
         docker images --digests --all 2>&1 | tee -a ./artifacts/docker.log
         echo "--------------------------------------------------" >> ./artifacts/docker.log
         docker-compose -f << parameters.docker_compose_file >> pull
-        echo "List of docker images in local cache AFTER pull" > ./artifacts/docker.log        
+        echo "List of docker images in local cache AFTER pull" > ./artifacts/docker.log
         docker images --digests --all 2>&1 | tee -a ./artifacts/docker.log
         echo "--------------------------------------------------" >> ./artifacts/docker.log
-        
+
   # Run a background task to display the running containers and their hash
   # This is used to verify that the right containers are running
   # Sleep 30s to give containers time to start
@@ -213,7 +213,7 @@ steps:
       name: Print the currently running containers
       background: true
       command: |
-        cd << parameters.tests_path >>        
+        cd << parameters.tests_path >>
         sleep 30
         docker ps --all --no-trunc 2>&1 | tee -a ./artifacts/docker.log
 

--- a/src/jobs/integration-tests.yml
+++ b/src/jobs/integration-tests.yml
@@ -192,6 +192,20 @@ steps:
         docker build -t << parameters.tests_image >> .
         docker save -o tests_image.tar << parameters.tests_image >>
 
+  # Pull the latest version of ${JAHIA_IMAGE}
+  - run:
+      name: Pull the latest version of the docker images listed in compose
+      command: |
+        cd << parameters.tests_path >>
+        . ./set-env.sh
+        echo "List of docker images in local cache PRIOR pull" > ./artifacts/docker.log
+        docker images --digests --all 2>&1 | tee -a ./artifacts/docker.log
+        echo "--------------------------------------------------" >> ./artifacts/docker.log
+        docker-compose -f << parameters.docker_compose_file >> pull
+        echo "List of docker images in local cache AFTER pull" > ./artifacts/docker.log        
+        docker images --digests --all 2>&1 | tee -a ./artifacts/docker.log
+        echo "--------------------------------------------------" >> ./artifacts/docker.log
+        
   # Run a background task to display the running containers and their hash
   # This is used to verify that the right containers are running
   # Sleep 30s to give containers time to start
@@ -199,9 +213,9 @@ steps:
       name: Print the currently running containers
       background: true
       command: |
-        cd << parameters.tests_path >>
+        cd << parameters.tests_path >>        
         sleep 30
-        docker ps --all --no-trunc 2>&1 | tee ./artifacts/docker-ps.log
+        docker ps --all --no-trunc 2>&1 | tee -a ./artifacts/docker.log
 
   # Using abort-on-container-exit will exit on first container failure, which
   # for us will be the test container
@@ -212,7 +226,6 @@ steps:
         export DOCKER_CLIENT_TIMEOUT=120
         export COMPOSE_HTTP_TIMEOUT=120
         . ./set-env.sh
-        docker pull ${JAHIA_IMAGE}
         docker-compose -f << parameters.docker_compose_file >> up --abort-on-container-exit
 
   - run:

--- a/src/jobs/sonar-analysis.yml
+++ b/src/jobs/sonar-analysis.yml
@@ -17,6 +17,10 @@ parameters:
     type: string
     default: "~/source"
     description: "Working directory for the job"
+  no_output_timeout:
+    type: string
+    default: "15m"
+    description: Maximum acceptable period of time to be passed with no output.
 
 working_directory: << parameters.working_directory >>
 
@@ -43,6 +47,7 @@ steps:
   - sonar-analysis:
       github_slug: << parameters.github_slug >>
       primary_release_branch: << parameters.primary_release_branch >>
+      no_output_timeout: << parameters.no_output_timeout >>
   - save_cache:
       paths:
         - ~/.owasp/dependency-check-data

--- a/src/jobs/static-analysis.yml
+++ b/src/jobs/static-analysis.yml
@@ -30,7 +30,11 @@ parameters:
   auditci_level:
     type: string
     default: "moderate"
-    description: "Security level to check against, will fail the step if higher"
+    description: "Security level to check against for the module codebase, will fail the step if higher"
+  auditci_level_tests:
+    type: string
+    default: "critical"
+    description: "Security level to check against for the tests codebase, will fail the step if higher"
 
 working_directory: << parameters.working_directory >>
 
@@ -54,3 +58,4 @@ steps:
       module_path: << parameters.module_path >>
       tests_path: << parameters.tests_path >>
       auditci_level: << parameters.auditci_level >>
+      auditci_level_tests: << parameters.auditci_level_tests >>


### PR DESCRIPTION
 - Added variable to differentiate audit-ci between module and tests codebases. Changed the default for tests to critical
 - Added a no_output_timetout to sonar-analysis job and command
 - Added debug data (images in cache) to the integration tests job