### PR TITLE
fix first build  of sub projects

### DIFF
--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -33,7 +33,7 @@ steps:
         - v1-maven-dependencies-{{ checksum "maven_cache_seed" }}
   - run:
       name: Build package and load all dependencies into local Maven repository
-      command: mvn -s .circleci/.circleci.settings.xml clean package de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+      command: mvn -s .circleci/.circleci.settings.xml clean install de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
   # Environment provisioning is sometimes dependent upon dependencies build during mvn clean package/install
   # This step copies those dependencies and make them available for further actions,
   # such as being used to provision a running Jahia with a set of freshly built artifacts


### PR DESCRIPTION
This allows the first build of a project with sub project with inner dependencies.

Currently the command:
```
mvn -s .circleci/.circleci.settings.xml dependency:copy-dependencies
```
fail when switching to a new version because the local repository does not contain the new version artifacts.
See: https://app.circleci.com/pipelines/github/Jahia/jexperience/595/workflows/98beb69d-2fcb-4a10-a6de-395f263b249f/jobs/1533
This change fill the repository with all required artefacts. 