### PR TITLE
Remove git workaround

### DIFF
--- a/src/commands/sonar-analysis.yml
+++ b/src/commands/sonar-analysis.yml
@@ -24,10 +24,6 @@ steps:
           -DretireJsAnalyzerEnabled=false -DnodeAnalyzerEnabled=false -DdataDirectory=/home/circleci/.owasp/dependency-check-data
       command: |
         if [[ ! -z "$CIRCLE_PULL_REQUEST" ]]; then
-          # echo "Git custom command to fix circle-ci checkout for sonar analysis"
-          git fetch --all
-          git branch -D << parameters.primary_release_branch >>
-          git rev-parse origin/<< parameters.primary_release_branch >>
           echo "Executing a PR based analysis"
           mvn -s .circleci/.circleci.settings.xml sonar:sonar \
               -Dsonar.pullrequest.branch=$CIRCLE_BRANCH \


### PR DESCRIPTION
## Description

With https://jira.jahia.org/browse/BACKLOG-14111 we added a git related workaround before the pull-request Sonar check, because of CircleCI bug, which got fixed with: 
https://discuss.circleci.com/t/git-checkout-of-a-branch-destroys-local-reference-to-master/23781/16

On jahia-private we did that removal already 3 months ago and its good.