### PR TITLE
[semver:patch] - Fixed issue with npm cache

### DIFF
--- a/src/jobs/initialize.yml
+++ b/src/jobs/initialize.yml
@@ -48,7 +48,7 @@ steps:
           yarn
         fi
   - save_cache:
-      key: v1-npm-{{ checksum "<< parameters.tests_path >>yarn.lock" }}
+      key: v1-npm-{{ checksum "yarn.lock" }}
       paths:
         - << parameters.module_path >>node_modules
         - << parameters.tests_path >>node_modules


### PR DESCRIPTION
The cache was not using the same key between save and restore, resulting in it being re-generated every time.