### PR TITLE
Fail Audit-CI on high level and above only

### DIFF
--- a/src/commands/security.yml
+++ b/src/commands/security.yml
@@ -16,7 +16,7 @@ parameters:
     description: "Path to the integration tests"
   auditci_level:
     type: string
-    default: "moderate"
+    default: "high"
     description: "Security level to check against for the module codebase, will fail the step if higher"
   auditci_level_tests:
     type: string


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-210

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Right now Audit CI is flagging moderate vulnerabilities and stopping build. I think had a discussion with @bpapez before that we should be ok setting this at least to "high" level instead.
