### PR TITLE
[semver:patch] TECH-502 : use jahia/cimg-mvn-cache by default for build

### DIFF
--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -15,7 +15,7 @@ parameters:
     description: "Working directory for the job"
   base_image:
     type: string
-    default: "cimg/openjdk:8.0.275"
+    default: "jahia/cimg-mvn-cache:cimg_openjdk_8.0.275"
     description: "Base docker image to be used for running the job"
   disable_circleci_cache:
     type: boolean


### PR DESCRIPTION
https://jira.jahia.org/browse/TECH-502