### PR TITLE
Update Ubuntu image used for machine executor

### DIFF
--- a/src/jobs/integration-tests-machine.yml
+++ b/src/jobs/integration-tests-machine.yml
@@ -15,7 +15,7 @@ parameters:
     description: "CircleCI resource_class (small, medium, large, xlarge, ...)"
   machine_image:
     type: string
-    default: "ubuntu-2004:202104-01"
+    default: "ubuntu-2004:202107-02"
     description: "Ubuntu image to run on the machine as per https://circleci.com/docs/2.0/configuration-reference/#available-machine-images"
   working_directory:
     type: string


### PR DESCRIPTION
As per the docs:
https://circleci.com/docs/2.0/configuration-reference/#machine
<img width="799" alt="Screen Shot 2021-11-10 at 8 22 01 AM" src="https://user-images.githubusercontent.com/5667028/141120770-ada19608-6073-430a-b925-396fa3b1bf08.png">


