### PR TITLE
[semver:patch] - Updated the command to use the latest version of jahia-reporter

### DIFF
--- a/src/commands/integration-tests.yml
+++ b/src/commands/integration-tests.yml
@@ -132,6 +132,10 @@ parameters:
     type: env_var_name
     default: INCIDENT_PAGERDUTY_REPORTER_EMAIL
     description: "Pageduty Reporter email to create incident. That email must correspond to a valid user in the PagerDuty tenant"
+  incident_pagerduty_reporter_id:
+    type: env_var_name
+    default: INCIDENT_PAGERDUTY_REPORTER_ID
+    description: "Pageduty Reporter id to create incident. This user will first be assigned to the ticket when --pdTwoStepsAssign is provided"
   incident_google_spreadsheet_id:
     type: env_var_name
     default: INCIDENT_GOOGLE_SPREADSHEET_ID
@@ -378,7 +382,7 @@ steps:
       name: Create incident in PagerDuty
       when: on_fail
       command: |
-        if [ << parameters.primary_release_branch >> == $CIRCLE_BRANCH ]; then
+        if [ << parameters.primary_release_branch >> == $CIRCLE_BRANCH ] || [ master == $CIRCLE_BRANCH ]; then
           cd << parameters.tests_path >>
           if [ "<< parameters.parent_executor >>" == "machine" ]; then
               echo "Running in a machine executor"
@@ -391,6 +395,8 @@ steps:
             --sourceType="json" \
             --pdApiKey=${<< parameters.incident_pagerduty_api_key >>} \
             --pdReporterEmail=${<< parameters.incident_pagerduty_reporter_email >>} \
+            --pdReporterId=${<< parameters.incident_pagerduty_reporter_id >>} \
+            --pdTwoStepsAssign \
             --googleSpreadsheetId=${<< parameters.incident_google_spreadsheet_id >>} \
             --googleClientEmail=${<< parameters.incident_google_client_email >>} \
             --googleApiKey=${<< parameters.incident_google_api_key_base64 >>} \


### PR DESCRIPTION
Dealing with incident assignees in Pagerduty is not the easiest.

If I understand the logic properly, PargerDuty does not have a notion of slack notifications in the desired method a user can choose from (only email, phone, pagerduty app). If a user is not "on-call" when an incident is created, he/she does not get pinged on slack (`@user`), his/her name is shown on slack as attached to the ticket but this does not generate notifications.

In our use case we don't want anyone to be "on-call" for such incidents, but only be notified on slack (no email, no phone, no pagerduty app) when a new incident is created.

<img width="585" alt="Screen Shot 2021-11-17 at 3 44 11 PM" src="https://user-images.githubusercontent.com/5667028/142279445-05256c13-f104-46d0-b347-b7483af16940.png">

When an incident is re-assigned to a user, this user gets notified on slack, no matter to the on-call schedule.

This allows us to ensure that a user is actually notified on slack when assigned to a ticket.