### PR TITLE
[semver:patch] - INFRA-2009: set skipSystemScope to true in OWASP check

### DIFF
--- a/src/commands/sonar-analysis.yml
+++ b/src/commands/sonar-analysis.yml
@@ -18,7 +18,7 @@ steps:
       name: Sonar Release branch analysis
       environment:
         DEPENDENCY_CHECK_SETTINGS:
-          -DfailOnError=false -DskipProvidedScope=true -DskipTestScope=false -Dformats=HTML,JSON
+          -DfailOnError=false -DskipProvidedScope=true -DskipTestScope=false -DskipSystemScope=true -Dformats=HTML,JSON
           -Dsonar.dependencyCheck.jsonReportPath=target/dependency-check-report.json
           -Dsonar.dependencyCheck.htmlReportPath=target/dependency-check-report.html
           -DretireJsAnalyzerEnabled=false -DnodeAnalyzerEnabled=false -DdataDirectory=/home/circleci/.owasp/dependency-check-data


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/INFRA-2009

## Description

Set skipSystemScope to true to avoid the Analysis exception "Unable to resolve system scoped dependency: com.sun:tools:jar:1.8.0:system" being displayed in the OWASP dependency check dashboard.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
