### PR TITLE
[semver:patch] - Updated to the lates jahia/cimg-mvn-cache docker image

### DIFF
--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -15,7 +15,7 @@ parameters:
     description: "Working directory for the job"
   base_image:
     type: string
-    default: "jahia/cimg-mvn-cache:cimg_openjdk_8.0.275"
+    default: "jahia/cimg-mvn-cache:cimg_openjdk_8.0.312-node"
     description: "Base docker image to be used for running the job"
   module_id:
     type: string

--- a/src/jobs/release.yml
+++ b/src/jobs/release.yml
@@ -8,7 +8,7 @@ parameters:
     description: "Name of the primary release branch (master, main, ...)"
   base_image:
     type: string
-    default: "jahia/cimg-mvn-cache:cimg_openjdk_8.0.275"
+    default: "jahia/cimg-mvn-cache:cimg_openjdk_8.0.312-node"
     description: "Base docker image to be used for running the job"
   module_id:
     type: string

--- a/src/jobs/sonar-analysis.yml
+++ b/src/jobs/sonar-analysis.yml
@@ -15,7 +15,7 @@ parameters:
     description: "CircleCI resource_class (small, medium, large, xlarge, ...)"
   base_image:
     type: string
-    default: "jahia/cimg-mvn-cache:cimg_openjdk_8.0.275"
+    default: "jahia/cimg-mvn-cache:cimg_openjdk_8.0.312-node"
     description: "Base docker image to be used for running the job"
   working_directory:
     type: string


### PR DESCRIPTION
This was needed to fix an issue with the release job.

I'll wait for the cimg image to be available before merging: https://app.circleci.com/pipelines/github/Jahia/cimg-mvn-cache/218/workflows/d05dd563-83a4-4013-9844-0ff46432fd59/jobs/229