### PR TITLE
Add the ability to specify a service different from module ID.

### DIFF
--- a/src/commands/integration-tests.yml
+++ b/src/commands/integration-tests.yml
@@ -148,6 +148,10 @@ parameters:
     type: env_var_name
     default: INCIDENT_GOOGLE_PRIVATE_KEY_BASE64
     description: "Google base64 encoded private key to allow access to Google API"
+  incident_service:
+    type: string
+    default: ""
+    description: "Default to Module ID, name of the Test Service to use for incident reporting"
   testrail_project:
     type: string
     default: "Default"
@@ -401,6 +405,12 @@ steps:
               [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
               nvm use --lts
           fi
+          if [ "<< parameters.incident_service >>" == "" ]; then
+            INCIDENT_SERVICE=<< parameters.module_id >>
+          else
+            INCIDENT_SERVICE=<< parameters.incident_service >>
+          fi
+          echo "Using Service (Test Service in the spreadsheet): ${INCIDENT_SERVICE}"
           jahia-reporter pagerduty:incident \
             --sourcePath="artifacts/results/xml_reports" \
             --sourceType="xml" \
@@ -411,7 +421,7 @@ steps:
             --googleSpreadsheetId=${<< parameters.incident_google_spreadsheet_id >>} \
             --googleClientEmail=${<< parameters.incident_google_client_email >>} \
             --googleApiKey=${<< parameters.incident_google_api_key_base64 >>} \
-            --service=<< parameters.module_id >> \
+            --service=${INCIDENT_SERVICE} \
             --sourceUrl=$CIRCLE_BUILD_URL
         fi
   - run:

--- a/src/jobs/integration-tests-machine.yml
+++ b/src/jobs/integration-tests-machine.yml
@@ -119,6 +119,10 @@ parameters:
     type: boolean
     default: true
     description: "Should the orb attend to build the test image"
+  incident_service:
+    type: string
+    default: ""
+    description: "Default to Module ID, name of the Test Service to use for incident reporting"    
   zencrepes_secret:
     type: env_var_name
     default: ZENCREPES_WEBHOOK_SECRET
@@ -203,6 +207,7 @@ steps:
       should_skip_zencrepes: << parameters.should_skip_zencrepes >>
       should_build_testsimage: << parameters.should_build_testsimage >>
       zencrepes_secret: << parameters.zencrepes_secret >>
+      incident_service: << parameters.incident_service >>
       testrail_project: << parameters.testrail_project >>
       testrail_milestone: << parameters.testrail_milestone >>
       testrail_username: << parameters.testrail_username >>

--- a/src/jobs/integration-tests-machine.yml
+++ b/src/jobs/integration-tests-machine.yml
@@ -122,7 +122,7 @@ parameters:
   incident_service:
     type: string
     default: ""
-    description: "Default to Module ID, name of the Test Service to use for incident reporting"    
+    description: "Default to Module ID, name of the Test Service to use for incident reporting"
   zencrepes_secret:
     type: env_var_name
     default: ZENCREPES_WEBHOOK_SECRET

--- a/src/jobs/integration-tests.yml
+++ b/src/jobs/integration-tests.yml
@@ -142,7 +142,7 @@ parameters:
   incident_service:
     type: string
     default: ""
-    description: "Default to Module ID, name of the Test Service to use for incident reporting"    
+    description: "Default to Module ID, name of the Test Service to use for incident reporting"
   ci_startup_script:
     type: string
     default: "ci.startup.sh"

--- a/src/jobs/integration-tests.yml
+++ b/src/jobs/integration-tests.yml
@@ -139,6 +139,10 @@ parameters:
     type: env_var_name
     default: TESTRAIL_PASSWORD
     description: "Testtrail Password"
+  incident_service:
+    type: string
+    default: ""
+    description: "Default to Module ID, name of the Test Service to use for incident reporting"    
   ci_startup_script:
     type: string
     default: "ci.startup.sh"
@@ -196,6 +200,7 @@ steps:
       slack_webhook_notifications_all: << parameters.slack_webhook_notifications_all >>
       should_skip_zencrepes: << parameters.should_skip_zencrepes >>
       should_build_testsimage: << parameters.should_build_testsimage >>
+      incident_service: << parameters.incident_service >>
       zencrepes_secret: << parameters.zencrepes_secret >>
       testrail_project: << parameters.testrail_project >>
       testrail_milestone: << parameters.testrail_milestone >>


### PR DESCRIPTION
This will cover cases for which we want to report execution differently based on a defined service.

For example, one reporting path for cluster, one reporting path for non cluster.