### PR TITLE
TECH-592: Prevent command from failing when no match

### DIFF
--- a/src/commands/update-module-signature.yml
+++ b/src/commands/update-module-signature.yml
@@ -75,7 +75,7 @@ steps:
       name: Handling signature update for single or multiple submodules
       command: |
         cd <<parameters.root_directory>>
-        modules_to_sign=($(ls -d */ | egrep -v "^<<parameters.except_folders>>"))
+        modules_to_sign=($(ls -d */ | egrep -v "^<<parameters.except_folders>>" || true))
         if [[ -z "$modules_to_sign" ]]; then
           for module_dir in ${modules_to_sign[@]}; do
             echo "Try to sign module" $module_dir
@@ -121,6 +121,8 @@ steps:
             fi
             cd <<parameters.root_directory>>
           done
+        else
+          echo "No modules to sign"
         fi
   - run:
       name: Handling signature for a single module


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-592

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Call to `update-module-signature` fails unexpectedly when there are no modules to sign. This is because Circle CI adds `-eo pipefail` option and that a `grep` call with no matches returns a failure exit code.

Mask grep exit code by adding `|| true` and treat `modules_to_sign` as empty